### PR TITLE
Fix typo for Github::Api

### DIFF
--- a/custom_download_strategy.rb
+++ b/custom_download_strategy.rb
@@ -103,6 +103,6 @@ class GitHubPrivateRepositoryReleaseDownloadStrategy < GitHubPrivateRepositoryDo
 
   def fetch_release_metadata
     release_url = "https://api.github.com/repos/#{@owner}/#{@repo}/releases/tags/#{@tag}"
-    GitHub::Api.open_rest(release_url)
+    GitHub::API.open_rest(release_url)
   end
 end


### PR DESCRIPTION
This PR is to fix the typo as mentioned by Brenton in https://github.com/cultureamp/homebrew-perform-cli/pull/2/files#r602702152