### PR TITLE
[ASP-307] Integrate with Backstage

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,24 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: homebrew-perform-cli
+  description: Brew tap for the perform cli
+  links:
+    - title: Website
+      url: https://github.com/cultureamp/homebrew-perform-cli
+
+  tags: 
+    - tier-3
+    - users-na
+    - camp-perform
+    - data-none
+    - atlas
+
+  annotations:
+    github.com/project-slug: cultureamp/homebrew-perform-cli
+    github.com/team-slug: cultureamp/atlas
+
+spec:
+  type: library
+  owner: atlas
+  lifecycle: development


### PR DESCRIPTION
## Purpose

This PR adds the configuration required for your component to be registered in our service catalogue "Backstage" - [Access Backstage](https://backstage.usw2.dev-us.cultureamp.io) (Dev VPN required)

## Before Merging

All comments in the `catalog-info.yaml` should be deleted before merging as their only purpose is to support this PR.  

It is strongly recommended you review and change this PR to suit the component in this repo with as much detail as possible.

Please consult the [backstage docs](https://backstage.usw2.dev-us.cultureamp.io/catalog/default/component/backstage/docs) and reach out to Mark Walford or the central SRE team #team_sre for help.

## Changes

This PR adds the following:

A `catalog-info.yaml` file. Required by backstage, this file defines this repo in the service catalog.
 The `catalog-info.yaml` is not complete. Please review and makes changes where necessary. Remove all comments.